### PR TITLE
Improve readme compatibility with PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ QueueAutomator provides a clean decorator API to get started with multiprocessin
 
 How it works:
 
-![QueueDiagram](./img/QueueDiagram.jpg)
+![QueueDiagram](https://raw.githubusercontent.com/Wason1797/QueueAutomator/develop/img/QueueDiagram.jpg)
 
 ### Example
 


### PR DESCRIPTION
Using the raw path allows the image to be used outside the github app