### PR TITLE
Use ordered data structure to keep track of queue processes

### DIFF
--- a/.github/workflows/publish_rolling_release.yml
+++ b/.github/workflows/publish_rolling_release.yml
@@ -2,7 +2,7 @@ name: Publish Python 🐍 distributions 📦 to TestPyPI
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ "rc" ]
 
 jobs:
   deploy:

--- a/src/queue_automator/main.py
+++ b/src/queue_automator/main.py
@@ -192,11 +192,11 @@ class QueueAutomator:
 
         self.__generate_queues(queues, manager, QueueNames.INPUT)
 
-        process_per_queue = {input_queue: self.__spawn_processes(input_queue, output_queue) for input_queue, output_queue in queues}
+        process_per_queue = tuple((input_queue, self.__spawn_processes(input_queue, output_queue)) for input_queue, output_queue in queues)
 
         self.__enqueue_input_data()
 
-        for queue_name, procesess in process_per_queue.items():
+        for queue_name, procesess in process_per_queue:
             current_queue = self.__queue_table[queue_name]
             current_queue['queue'].join()
             self.__signal_queue_exit(current_queue['queue'], current_queue['process_count'])


### PR DESCRIPTION
Fix potential sync bugs with processes being joined out of order 

* A dictionary is unordered, this could cause issues when joining processes since this operation needs to be done in order

* Using a tuple is the best option here, since it is immutable and the structure is simple enough

Push rolling releases with rc branch, not develop